### PR TITLE
Glm/schema update

### DIFF
--- a/plugins/FelixCardController.cpp
+++ b/plugins/FelixCardController.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 /**
  * @brief Name used by TRACE TLOG calls from this source file
@@ -43,9 +44,10 @@ FelixCardController::FelixCardController(const std::string& name)
   : DAQModule(name)
   , m_is_aligned(false)
 {
-  m_card_wrapper = std::make_unique<CardControllerWrapper>();
+  //m_card_wrapper = std::make_unique<CardControllerWrapper>();
 
   register_command("conf", &FelixCardController::do_configure);
+  register_command("start", &FelixCardController::gth_reset);
   register_command("getregister", &FelixCardController::get_reg);
   register_command("setregister", &FelixCardController::set_reg);
   register_command("getbitfield", &FelixCardController::get_bf);
@@ -54,22 +56,29 @@ FelixCardController::FelixCardController(const std::string& name)
 }
 
 void
-FelixCardController::init(const data_t& args)
+FelixCardController::init(const data_t& /*args*/)
 {
-  m_card_wrapper->init(args);
 }
 
 void
 FelixCardController::do_configure(const data_t& args)
 {
   m_cfg = args.get<felixcardcontroller::Conf>();
-  m_card_wrapper->configure(args);
+  for (auto lu : m_cfg.logical_units) {
+     uint32_t id = m_cfg.card_id+lu.log_unit_id;
+     m_card_wrappers.emplace(std::make_pair(id,std::make_unique<CardControllerWrapper>(id)));
+     if(m_card_wrappers.size() == 1) {
+	 // Do the init only for the first device (whole card)
+         m_card_wrappers.begin()->second->init();
+     }
+     m_card_wrappers.at(m_cfg.card_id+lu.log_unit_id)->configure(lu);
+  }
 }
 
 void
 FelixCardController::get_info(opmonlib::InfoCollector& ci, int /*level*/)
 {
-  //GLM: FIXME! Loop over all logical units and over all enabled channels using the m_cfg information
+  /*GLM: FIXME! Loop over all logical units and over all enabled channels using the m_cfg information
   felixcardcontrollerinfo::ChannelInfo info;
 
   uint64_t aligned = m_card_wrapper->get_register(REG_GBT_ALIGNMENT_DONE);     // NOLINT(build/unsigned)
@@ -99,14 +108,16 @@ FelixCardController::get_info(opmonlib::InfoCollector& ci, int /*level*/)
   info.channel04_alignment_status = stats[4];
   info.channel05_alignment_status = stats[5];
   ci.add(info);
-}
+*/
+  }
 
 void
 FelixCardController::get_reg(const data_t& args)
 {
   auto conf = args.get<felixcardcontroller::GetRegisters>();
+  auto id = conf.card_id + conf.log_unit_id;
   for (auto reg_name : conf.reg_names) {
-    auto reg_val = m_card_wrapper->get_register(reg_name);
+    auto reg_val = m_card_wrappers.at(id)->get_register(reg_name);
     TLOG() << reg_name << "        0x" << std::hex << reg_val;
   }
 }
@@ -115,8 +126,10 @@ void
 FelixCardController::set_reg(const data_t& args)
 {
   auto conf = args.get<felixcardcontroller::SetRegisters>();
+  auto id = conf.card_id + conf.log_unit_id;
+
   for (auto p : conf.reg_val_pairs) {
-    m_card_wrapper->set_register(p.reg_name, p.reg_val);
+    m_card_wrappers.at(id)->set_register(p.reg_name, p.reg_val);
   }
 }
 
@@ -124,8 +137,10 @@ void
 FelixCardController::get_bf(const data_t& args)
 {
   auto conf = args.get<felixcardcontroller::GetBFs>();
+  auto id = conf.card_id + conf.log_unit_id;
+
   for (auto bf_name : conf.bf_names) {
-    auto bf_val = m_card_wrapper->get_bitfield(bf_name);
+    auto bf_val = m_card_wrappers.at(id)->get_bitfield(bf_name);
     TLOG() << bf_name << "        0x" << std::hex << bf_val;
   }
 }
@@ -134,15 +149,18 @@ void
 FelixCardController::set_bf(const data_t& args)
 {
   auto conf = args.get<felixcardcontroller::SetBFs>();
+  auto id = conf.card_id + conf.log_unit_id;
+
   for (auto p : conf.bf_val_pairs) {
-    m_card_wrapper->set_bitfield(p.reg_name, p.reg_val);
+    m_card_wrappers.at(id)->set_bitfield(p.reg_name, p.reg_val);
   }
 }
 
 void
 FelixCardController::gth_reset(const data_t& /*args*/)
 {
-  m_card_wrapper->gth_reset();
+  // Do the reset only for the first device (whole card)
+  m_card_wrappers.begin()->second->gth_reset();
 }
 
 } // namespace flxlibs

--- a/plugins/FelixCardController.cpp
+++ b/plugins/FelixCardController.cpp
@@ -42,7 +42,6 @@ namespace flxlibs {
 
 FelixCardController::FelixCardController(const std::string& name)
   : DAQModule(name)
-  , m_is_aligned(false)
 {
   //m_card_wrapper = std::make_unique<CardControllerWrapper>();
 
@@ -78,38 +77,23 @@ FelixCardController::do_configure(const data_t& args)
 void
 FelixCardController::get_info(opmonlib::InfoCollector& ci, int /*level*/)
 {
-  /*GLM: FIXME! Loop over all logical units and over all enabled channels using the m_cfg information
-  felixcardcontrollerinfo::ChannelInfo info;
-
-  uint64_t aligned = m_card_wrapper->get_register(REG_GBT_ALIGNMENT_DONE);     // NOLINT(build/unsigned)
-  uint64_t number_channels = m_card_wrapper->get_register(BF_NUM_OF_CHANNELS); // NOLINT(build/unsigned)
-
-  std::vector<int> stats(number_channels, 0);
-  size_t num_aligned = 0;
-  //GLM: FIXME auto index = m_logical_unit * number_channels;
-  auto index = number_channels;
-  for (size_t i = 0; i < number_channels; ++i) {
-    if (aligned & (1 << index)) {
-      stats[i] = 1;
-      num_aligned++;
-    } else if (m_is_aligned) {
-      m_is_aligned = false;
-      ers::warning(ChannelAlignment(ERS_HERE, index));
-    }
-    index++;
+  for (auto lu : m_cfg.logical_units) {
+     uint32_t id = m_cfg.card_id+lu.log_unit_id;
+     uint64_t aligned = m_card_wrappers.at(id)->get_register(REG_GBT_ALIGNMENT_DONE);
+     for( auto li : lu.links) {
+	felixcardcontrollerinfo::LinkInfo info;
+	info.device_id = id;
+	info.link_id = li.link_id;
+	info.enabled = li.enabled;
+	info.aligned = aligned & (1<<li.link_id);
+        opmonlib::InfoCollector tmp_ic;
+	std::stringstream info_name;
+	info_name << "device_" << id << "_link_" << li.link_id; 
+        tmp_ic.add(info);
+	ci.add(info_name.str(),tmp_ic);
+     }
   }
-
-  m_is_aligned = (num_aligned < number_channels ? false : true);
-
-  info.channel00_alignment_status = stats[0];
-  info.channel01_alignment_status = stats[1];
-  info.channel02_alignment_status = stats[2];
-  info.channel03_alignment_status = stats[3];
-  info.channel04_alignment_status = stats[4];
-  info.channel05_alignment_status = stats[5];
-  ci.add(info);
-*/
-  }
+}
 
 void
 FelixCardController::get_reg(const data_t& args)

--- a/plugins/FelixCardController.hpp
+++ b/plugins/FelixCardController.hpp
@@ -53,8 +53,6 @@ private:
 
   // Configuration
   module_conf_t m_cfg;
-  uint8_t m_card_id;      // NOLINT
-  uint8_t m_logical_unit; // NOLINT
 
   // State
   bool m_is_aligned;

--- a/plugins/FelixCardController.hpp
+++ b/plugins/FelixCardController.hpp
@@ -57,8 +57,8 @@ private:
   // State
   bool m_is_aligned;
 
-  // FELIX Cards
-  std::unique_ptr<CardControllerWrapper> m_card_wrapper;
+  // FELIX Card
+  std::map<uint32_t, std::unique_ptr<CardControllerWrapper> > m_card_wrappers;
 };
 
 } // namespace flxlibs

--- a/plugins/FelixCardController.hpp
+++ b/plugins/FelixCardController.hpp
@@ -54,9 +54,6 @@ private:
   // Configuration
   module_conf_t m_cfg;
 
-  // State
-  bool m_is_aligned;
-
   // FELIX Card
   std::map<uint32_t, std::unique_ptr<CardControllerWrapper> > m_card_wrappers;
 };

--- a/python/flxlibs/cardcontrollerapp/cardcontrollerapp_gen.py
+++ b/python/flxlibs/cardcontrollerapp/cardcontrollerapp_gen.py
@@ -18,13 +18,12 @@ from appfwk.daqmodule import DAQModule
 #from appfwk.conf_utils import Direction, Connection
 
 #===============================================================================
-def get_cardcontroller_app(card_id, 
+def get_cardcontroller_app(nickname, card_id, 
                 host="localhost"):
     '''
     Here an entire application controlling one physical FLX card is generated. 
     '''
 
-    nickname = 'flx_card_'+host+'_'+str(card_id)
     # Define modules
 
     modules = []
@@ -32,10 +31,10 @@ def get_cardcontroller_app(card_id,
     links = [];
     lus = [];
     # Prepare standard config with 6 links per logical unit
-    for i in (0,5):
+    for i in range(6):
         links+=[flx.Link(link_id=i, enabled=True, dma_desc=0, superchunk_factor=12)]
     # Prepare standard config with 2 logical units per card
-    for j in (0,1):
+    for j in range(2):
         lus+=[flx.LogicalUnit(log_unit_id=j, emu_fanout=False, links=links)]
 
 

--- a/python/flxlibs/cardcontrollerapp/cardcontrollerapp_gen.py
+++ b/python/flxlibs/cardcontrollerapp/cardcontrollerapp_gen.py
@@ -1,0 +1,51 @@
+# This module facilitates the generation of FLX card controller apps
+
+# Set moo schema search path
+from dunedaq.env import get_moo_model_path
+import moo.io
+moo.io.default_load_path = get_moo_model_path()
+
+# Load configuration types
+import moo.otypes
+
+moo.otypes.load_types('flxlibs/felixcardcontroller.jsonnet')
+
+# Import new types
+import dunedaq.flxlibs.felixcardcontroller as flx
+
+from appfwk.app import App, ModuleGraph
+from appfwk.daqmodule import DAQModule
+#from appfwk.conf_utils import Direction, Connection
+
+#===============================================================================
+def get_cardcontroller_app(card_id, 
+                host="localhost"):
+    '''
+    Here an entire application controlling one physical FLX card is generated. 
+    '''
+
+    nickname = 'flx_card_'+host+'_'+str(card_id)
+    # Define modules
+
+    modules = []
+
+    links = [];
+    lus = [];
+    # Prepare standard config with 6 links per logical unit
+    for i in (0,5):
+        links+=[flx.Link(link_id=i, enabled=True, dma_desc=0, superchunk_factor=12)]
+    # Prepare standard config with 2 logical units per card
+    for j in (0,1):
+        lus+=[flx.LogicalUnit(log_unit_id=j, emu_fanout=False, links=links)]
+
+
+    modules += [DAQModule(name = nickname, 
+                          plugin = 'FelixCardController',
+                          conf = flx.Conf(card_id = card_id, logical_units = lus)
+                             )]
+
+    mgraph = ModuleGraph(modules)
+    flx_app = App(modulegraph=mgraph, host=host, name=nickname)
+
+    return flx_app
+

--- a/schema/flxlibs/felixcardcontroller.jsonnet
+++ b/schema/flxlibs/felixcardcontroller.jsonnet
@@ -6,11 +6,11 @@ local s = moo.oschema.schema(ns);
 
 // Object structure
 local felixcardcontroller = {
-    count  : s.number("Count", "u4",
-                      doc="Count of things"),
+    boolean : s.boolean("boolean",
+                      doc="A boolean"),
 
-    id : s.number("Identifier", "i4",
-                  doc="An ID of a thingy"),
+    uint4  : s.number("uint4", "u4",
+                      doc="An unsigned of 4 bytes"),
 
     uint8 : s.number("uint8", "u8",
                       doc="An unsigned of 8 bytes"),
@@ -31,39 +31,53 @@ local felixcardcontroller = {
     regvallist : s.sequence("RegValList", self.regvalpair,
                 doc="A list of registers and values"),
 
+    link : s.record("Link", [
+    s.field("link_id", self.uint4, doc="Link identifier"),
+    s.field("enabled", self.boolean, doc="Indicate whether the link is enabled"),
+    s.field("dma_desc", self.uint8, doc="DMA channel"),
+    s.field("superchunk_factor", self.uint4, doc="Superchunk factor")
+    ], doc=""),
+
+    links : s.sequence("LinksList", self.link,
+                doc="A list of links"),
+ 
+    logical_unit: s.record("LogicalUnit", [
+    s.field("log_unit_id", self.uint4, doc="Logical unit identifier"),
+    s.field("links", self.links, doc="List of links in the logical unit"),
+    ], doc=""),
+    
+    logical_units : s.sequence("LogicalUnitList", self.logical_unit,
+                doc="A list of logical units"),
+
     conf: s.record("Conf", [
-    s.field("card_id", self.id, 0,
+    s.field("card_id", self.uint4, 0,
             doc="Physical card identifier (in the same host)"),
 
-    s.field("logical_unit", self.count, 0,
-            doc="Superlogic region of selected card"),
+    s.field("logical_units", self.logical_units,
+            doc="Superlogic regions of selected card"),
 
     ], doc="Upstream FELIX CardController DAQ Module Configuration"),
 
-    getregister: s.record("GetRegisterParams", [
+    getregister: s.record("GetRegisters", [
     s.field("reg_names", self.reglist,
                 doc="A list of registers")
     ], doc="Register access parameters"),
 
-    setregister: s.record("SetRegisterParams", [
+    setregister: s.record("SetRegisters", [
     s.field("reg_val_pairs", self.regvallist,
                 doc="A list of registers and values to set")
     ], doc="Register access parameters"),
 
-    getbitfield: s.record("GetBFParams", [
+    getbitfield: s.record("GetBFs", [
     s.field("bf_names", self.reglist,
                 doc="A list of bitfields")
     ], doc="Bitfield access parameters"),
 
-    setbitfield: s.record("SetBFParams", [
+    setbitfield: s.record("SetBFs", [
     s.field("bf_val_pairs", self.regvallist,
                 doc="A list of bitfields and values to set")
     ], doc="Bitfield access parameters"),
 
-    gthreset: s.record("GTHResetParams", [
-    s.field("quads", self.uint8, 0,
-                doc="Binary representation of which quads (0-5) to reset. Eg. 010000 to reset quad 4")
-    ], doc="GTH reciever reset parameters")
 };
 
 moo.oschema.sort_select(felixcardcontroller, ns)

--- a/schema/flxlibs/felixcardcontroller.jsonnet
+++ b/schema/flxlibs/felixcardcontroller.jsonnet
@@ -43,6 +43,7 @@ local felixcardcontroller = {
  
     logical_unit: s.record("LogicalUnit", [
     s.field("log_unit_id", self.uint4, doc="Logical unit identifier"),
+    s.field("emu_fanout", self.boolean, doc="Toggle emulator on/off"),
     s.field("links", self.links, doc="List of links in the logical unit"),
     ], doc=""),
     
@@ -59,21 +60,34 @@ local felixcardcontroller = {
     ], doc="Upstream FELIX CardController DAQ Module Configuration"),
 
     getregister: s.record("GetRegisters", [
+    s.field("card_id", self.uint4, 0,
+            doc="Physical card identifier (in the same host)"),
+    s.field("log_unit_id", self.uint4, doc="Logical unit identifier"),
     s.field("reg_names", self.reglist,
                 doc="A list of registers")
     ], doc="Register access parameters"),
 
     setregister: s.record("SetRegisters", [
+    s.field("card_id", self.uint4, 0,
+            doc="Physical card identifier (in the same host)"),
+    s.field("log_unit_id", self.uint4, doc="Logical unit identifier"),
+
     s.field("reg_val_pairs", self.regvallist,
                 doc="A list of registers and values to set")
     ], doc="Register access parameters"),
 
     getbitfield: s.record("GetBFs", [
+    s.field("card_id", self.uint4, 0,
+            doc="Physical card identifier (in the same host)"),
+    s.field("log_unit_id", self.uint4, doc="Logical unit identifier"),
     s.field("bf_names", self.reglist,
                 doc="A list of bitfields")
     ], doc="Bitfield access parameters"),
 
     setbitfield: s.record("SetBFs", [
+    s.field("card_id", self.uint4, 0,
+            doc="Physical card identifier (in the same host)"),
+    s.field("log_unit_id", self.uint4, doc="Logical unit identifier"),
     s.field("bf_val_pairs", self.regvallist,
                 doc="A list of bitfields and values to set")
     ], doc="Bitfield access parameters"),

--- a/schema/flxlibs/felixcardcontrollerinfo.jsonnet
+++ b/schema/flxlibs/felixcardcontrollerinfo.jsonnet
@@ -6,17 +6,19 @@ local moo = import "moo.jsonnet";
 local s = moo.oschema.schema("dunedaq.flxlibs.felixcardcontrollerinfo");
 
 local info = {
-    uint8 : s.number("uint8", "u8",
-        doc="An unsigned of 8 bytes"),
+    boolean : s.boolean("boolean",
+                      doc="A boolean"),
 
-info: s.record("ChannelInfo", [
-    s.field("channel00_alignment_status", self.uint8, 0, doc="Alignment status for channel 0"),
-    s.field("channel01_alignment_status", self.uint8, 0, doc="Alignment status for channel 1"),
-    s.field("channel02_alignment_status", self.uint8, 0, doc="Alignment status for channel 2"),
-    s.field("channel03_alignment_status", self.uint8, 0, doc="Alignment status for channel 3"),
-    s.field("channel04_alignment_status", self.uint8, 0, doc="Alignment status for channel 4"),
-    s.field("channel05_alignment_status", self.uint8, 0, doc="Alignment status for channel 5")
-], doc="Channel information")
+    uint4  : s.number("uint4", "u4",
+                      doc="An unsigned of 4 bytes"),
+
+    link : s.record("LinkInfo", [
+    s.field("device_id", self.uint4, doc="Device identifier"),
+    s.field("link_id", self.uint4, doc="Link identifier"),
+    s.field("enabled", self.boolean, doc="Indicate whether the link is enabled"),
+    s.field("aligned", self.boolean, doc="Indicate whether the link is aligned")
+    ], doc="Upstream FELIX Link information")
+
 };
 
 moo.oschema.sort_select(info)

--- a/scripts/felixcardcontrollerconf_gen.py
+++ b/scripts/felixcardcontrollerconf_gen.py
@@ -73,7 +73,8 @@ def cli(partition_name, host_flx, ncards, opmon_impl, ers_impl, pocket_url, json
    
 
     for i in (0,ncards-1):
-        the_system.apps[i]=cardcontrollerapp_gen.get_cardcontroller_app(i*2,host_flx)
+        nickname = 'flx_card_'+host_flx.replace('-', '_')+'_'+str(i*2)
+        the_system.apps[nickname]=cardcontrollerapp_gen.get_cardcontroller_app(nickname,i*2,host_flx)
 
     ####################################################################
     # Application command data generation

--- a/scripts/felixcardcontrollerconf_gen.py
+++ b/scripts/felixcardcontrollerconf_gen.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import math
+import sys
+import glob
+import rich.traceback
+from rich.console import Console
+from os.path import exists, join
+from appfwk.system import System
+from appfwk.conf_utils import make_app_command_data
+from daqconf.core.metadata import write_metadata_file
+
+# Add -h as default help option
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+console = Console()
+
+# Set moo schema search path
+from dunedaq.env import get_moo_model_path
+import moo.io
+moo.io.default_load_path = get_moo_model_path()
+
+import click
+
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('-P', '--partition-name', default="global", help="Name of the partition to use, for ERS and OPMON")
+@click.option('--host-flx', default='localhost', help='Server hosing the FLX card')
+@click.option('--ncards', default=1, help='Number of FLX cards in host')
+@click.option('--opmon-impl', type=click.Choice(['json','cern','pocket'], case_sensitive=False),default='json', help="Info collector service implementation to use")
+@click.option('--ers-impl', type=click.Choice(['local','cern','pocket'], case_sensitive=False), default='local', help="ERS destination (Kafka used for cern and pocket)")
+@click.option('--pocket-url', default='127.0.0.1', help="URL for connecting to Pocket services")
+@click.argument('json_dir', type=click.Path())
+
+def cli(partition_name, host_flx, ncards, opmon_impl, ers_impl, pocket_url, json_dir):
+
+    if exists(json_dir):
+        raise RuntimeError(f"Directory {json_dir} already exists")
+
+    console.log('Loading cardcontrollerapp config generator')
+    from flxlibs.cardcontrollerapp import cardcontrollerapp_gen
+
+    the_system = System(partition_name)
+   
+    if opmon_impl == 'cern':
+        info_svc_uri = "influx://opmondb.cern.ch:31002/write?db=influxdb"
+    elif opmon_impl == 'pocket':
+        info_svc_uri = "influx://" + pocket_url + ":31002/write?db=influxdb"
+    else:
+        info_svc_uri = "file://info_${APP_NAME}_${APP_PORT}.json"
+
+    ers_settings=dict()
+
+    if ers_impl == 'cern':
+        use_kafka = True
+        ers_settings["INFO"] =    "erstrace,throttle,lstdout,erskafka(monkafka.cern.ch:30092)"
+        ers_settings["WARNING"] = "erstrace,throttle,lstdout,erskafka(monkafka.cern.ch:30092)"
+        ers_settings["ERROR"] =   "erstrace,throttle,lstdout,erskafka(monkafka.cern.ch:30092)"
+        ers_settings["FATAL"] =   "erstrace,lstdout,erskafka(monkafka.cern.ch:30092)"
+    elif ers_impl == 'pocket':
+        use_kafka = True
+        ers_settings["INFO"] =    "erstrace,throttle,lstdout,erskafka(" + pocket_url + ":30092)"
+        ers_settings["WARNING"] = "erstrace,throttle,lstdout,erskafka(" + pocket_url + ":30092)"
+        ers_settings["ERROR"] =   "erstrace,throttle,lstdout,erskafka(" + pocket_url + ":30092)"
+        ers_settings["FATAL"] =   "erstrace,lstdout,erskafka(" + pocket_url + ":30092)"
+    else:
+        use_kafka = False
+        ers_settings["INFO"] =    "erstrace,throttle,lstdout"
+        ers_settings["WARNING"] = "erstrace,throttle,lstdout"
+        ers_settings["ERROR"] =   "erstrace,throttle,lstdout"
+        ers_settings["FATAL"] =   "erstrace,lstdout"
+   
+
+    for i in (0,ncards-1):
+        the_system.apps[i]=cardcontrollerapp_gen.get_cardcontroller_app(i*2,host_flx)
+
+    ####################################################################
+    # Application command data generation
+    ####################################################################
+
+    # Arrange per-app command data into the format used by util.write_json_files()
+    app_command_datas = {
+        name : make_app_command_data(the_system, app)
+        for name,app in the_system.apps.items()
+    }
+
+    # Make boot.json config
+    from appfwk.conf_utils import make_system_command_datas,generate_boot, write_json_files
+    system_command_datas = make_system_command_datas(the_system)
+    # Override the default boot.json with the one from minidaqapp
+    boot = generate_boot(the_system.apps, partition_name=partition_name, ers_settings=ers_settings, info_svc_uri=info_svc_uri,
+                              disable_trace=True, use_kafka=use_kafka)
+
+    system_command_datas['boot'] = boot
+
+    write_json_files(app_command_datas, system_command_datas, json_dir)
+
+    console.log(f"FLX card controller apps config generated in {json_dir}")
+    
+    write_metadata_file(json_dir, "flxcardcontrollers_gen")
+
+if __name__ == '__main__':
+    try:
+        cli(show_default=True, standalone_mode=True)
+    except Exception as e:
+        console.print_exception()

--- a/src/CardControllerWrapper.hpp
+++ b/src/CardControllerWrapper.hpp
@@ -27,7 +27,7 @@ public:
   /**
    * @brief CardControllerWrapper Constructor
    */
-  CardControllerWrapper();
+  CardControllerWrapper(uint32_t device_id);
   ~CardControllerWrapper();
   CardControllerWrapper(const CardControllerWrapper&) = delete;            ///< Not copy-constructible
   CardControllerWrapper& operator=(const CardControllerWrapper&) = delete; ///< Not copy-assignable
@@ -35,8 +35,8 @@ public:
   CardControllerWrapper& operator=(CardControllerWrapper&&) = delete;      ///< Not move-assignable
 
   using data_t = nlohmann::json;
-  void init(const data_t& args);
-  void configure(const data_t& args);
+  void init();
+  void configure(const felixcardcontroller::LogicalUnit & lu_cfg);
 
   uint64_t get_register(std::string key);             // NOLINT(build/unsigned)
   void set_register(std::string key, uint64_t value); // NOLINT(build/unsigned)
@@ -45,18 +45,13 @@ public:
   void gth_reset();
 
 private:
-  // Types
-  using module_conf_t = dunedaq::flxlibs::felixcardcontroller::Conf;
 
   // Card
   void open_card();
   void close_card();
 
-  // Configuration and internals
-  module_conf_t m_cfg;
-  bool m_configured{ false };
-
   // Card object
+  uint32_t m_device_id;
   using UniqueFlxCard = std::unique_ptr<FlxCard>;
   UniqueFlxCard m_flx_card;
   std::mutex m_card_mutex;

--- a/src/CardControllerWrapper.hpp
+++ b/src/CardControllerWrapper.hpp
@@ -42,7 +42,7 @@ public:
   void set_register(std::string key, uint64_t value); // NOLINT(build/unsigned)
   uint64_t get_bitfield(std::string key);             // NOLINT(build/unsigned)
   void set_bitfield(std::string key, uint64_t value); // NOLINT(build/unsigned)
-  void gth_reset(int quad);
+  void gth_reset();
 
 private:
   // Types
@@ -55,9 +55,6 @@ private:
   // Configuration and internals
   module_conf_t m_cfg;
   bool m_configured{ false };
-  uint8_t m_card_id;      // NOLINT
-  uint8_t m_logical_unit; // NOLINT
-  std::string m_card_id_str;
 
   // Card object
   using UniqueFlxCard = std::unique_ptr<FlxCard>;


### PR DESCRIPTION
This PR contains changes completing the functionality of the Felix card controller.
There is one card controller per physical FLX card. Each card controller instantiates as many card wrappers are there are logical devices in the card (typically 2).
At configure a fraction of flx_init is carried out, all links are disabled, the emulation settings are configured and, finally, the enabled links are enabled with the correct superchunk factor.
The script  felixcardcontrollerconf_gen.py generates the standard configuration for daq_application with configurable number of physical cards. This may be further developed in line with the devices/links mask that is being worked on in parallel for the flx card reader. I like the idea of keeping the card controller separate from the readout application, but, of course, this can be changed in the config generation.
Resolves #21 and closes #28.