### PR TITLE
Hristova/tp readouttype fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(flxlibs VERSION 1.3.1)
+project(flxlibs VERSION 1.5.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/test/apps/test_tp_elinkhandler_app.cxx
+++ b/test/apps/test_tp_elinkhandler_app.cxx
@@ -172,8 +172,8 @@ main(int argc, char* argv[])
 
       std::ostringstream oss;
       rwtpp->m_head.print(oss);
-      types::RAW_WIB_TRIGGERPRIMITIVE_STRUCT rwtps;
-      rwtps.rwtp.reset(rwtpp);
+      //types::RAW_WIB_TRIGGERPRIMITIVE_STRUCT rwtps; // TODO 2022-04-21 ivana.hristova@stfc.ac.uk: currently this pointer has been removed  
+      //rwtps.rwtp.reset(rwtpp);
       TLOG() << oss.str();
 
       if (amount > 1000) {


### PR DESCRIPTION
This PR is to fix a reference made to removed pointer in the raw WIB TP readout type.