### PR TITLE
Multiple Felix K8s resources

### DIFF
--- a/scripts/felixcardcontrollerconf_gen.py
+++ b/scripts/felixcardcontrollerconf_gen.py
@@ -88,7 +88,7 @@ def cli(config, hardware_map_file, emulator_mode, json_dir, debug):
         the_system.apps[nickname] = app
         if boot.use_k8s:
             the_system.apps[nickname].resources = {
-                "felix.cern/flx0-ctrl": "1", # requesting FLX0
+                f"felix.cern/flx{dro_info.card}-ctrl": "1", # requesting FLX {dro_info.card}
             }
 
     ####################################################################

--- a/scripts/felixcardcontrollerconf_gen.py
+++ b/scripts/felixcardcontrollerconf_gen.py
@@ -88,7 +88,7 @@ def cli(config, hardware_map_file, emulator_mode, json_dir, debug):
         the_system.apps[nickname] = app
         if boot.use_k8s:
             the_system.apps[nickname].resources = {
-                f"felix.cern/flx{dro_info.card}-ctrl": "1", # requesting FLX {dro_info.card}
+                f"felix.cern/flx{dro_info.card*2}-ctrl": "1", # requesting FLX {dro_info.card*2}
             }
 
     ####################################################################


### PR DESCRIPTION
Make it possible to run with >1 felix on the same host, by using the `DRO_Card` number from the HWMap