### PR TITLE
Reorganize daqconf schema options

### DIFF
--- a/schema/flxlibs/confgen.jsonnet
+++ b/schema/flxlibs/confgen.jsonnet
@@ -1,8 +1,12 @@
 // This is the configuration schema for timinglibs
 
 local moo = import "moo.jsonnet";
-local sdc = import "daqconf/confgen.jsonnet";
-local daqconf = moo.oschema.hier(sdc).dunedaq.daqconf.confgen;
+
+local sboot = import "daqconf/bootgen.jsonnet";
+local bootgen = moo.oschema.hier(sboot).dunedaq.daqconf.bootgen;
+local sdet = import "daqconf/detectorgen.jsonnet";
+local detectorgen = moo.oschema.hier(sdet).dunedaq.daqconf.detectorgen;
+
 
 local ns = "dunedaq.flxlibs.confgen";
 local s = moo.oschema.schema(ns);
@@ -10,22 +14,22 @@ local s = moo.oschema.schema(ns);
 // A temporary schema construction context.
 local cs = {
 
-  array: s.sequence("array", daqconf.count, "A list of counts."),
+  array: s.sequence("array", bootgen.count, "A list of counts."),
   alignment_mask: s.sequence("alignment_mask", self.array, "A list of arrays, should be 2 (1 for each SLR)"),
 
   flxcardcontroller: s.record('flxcardcontroller', [
-    s.field("detector_readout_map_file", daqconf.Path, default='./detro_map.json', doc="File containing detector readout map for configuration to run"),
-    s.field("emulator_mode",     daqconf.Flag, default=false, doc="If active, timestamps of data frames are overwritten when processed by the readout. This is necessary if the felix card does not set correct timestamps. Former -e"),
+    s.field("detector_readout_map_file", bootgen.Path, default='./detro_map.json', doc="File containing detector readout map for configuration to run"),
+    s.field("emulator_mode",     bootgen.Flag, default=false, doc="If active, timestamps of data frames are overwritten when processed by the readout. This is necessary if the felix card does not set correct timestamps. Former -e"),
     s.field("ignore_alignment_mask", self.alignment_mask, default=[[],[]], doc="elink numbers to ignore when checking link alignment."),
   ]),
 
   flxlibs_gen: s.record('flxlibs_gen', [
-    s.field('detector',          daqconf.detector,       default=daqconf.detector,       doc='detector parameters'),
-    s.field('boot',              daqconf.boot,           default=daqconf.boot,           doc='Boot parameters'),
+    s.field('detector',          detectorgen.detector,   default=detectorgen.detector,   doc='detector parameters'),
+    s.field('boot',              bootgen.boot,           default=bootgen.boot,           doc='Boot parameters'),
     s.field('flxcardcontroller', self.flxcardcontroller, default=self.flxcardcontroller, doc='FELIX conf parameters'),
   ]),
 
 };
 
 // Output a topologically sorted array.
-sdc + moo.oschema.sort_select(cs, ns)
+sboot + sdet + moo.oschema.sort_select(cs, ns)

--- a/schema/flxlibs/confgen.jsonnet
+++ b/schema/flxlibs/confgen.jsonnet
@@ -2,6 +2,9 @@
 
 local moo = import "moo.jsonnet";
 
+local stypes = import "daqconf/types.jsonnet";
+local types = moo.oschema.hier(stypes).dunedaq.daqconf.types;
+
 local sboot = import "daqconf/bootgen.jsonnet";
 local bootgen = moo.oschema.hier(sboot).dunedaq.daqconf.bootgen;
 
@@ -12,12 +15,12 @@ local s = moo.oschema.schema(ns);
 // A temporary schema construction context.
 local cs = {
 
-  array: s.sequence("array", bootgen.count, "A list of counts."),
+  array: s.sequence("array", types.count, "A list of counts."),
   alignment_mask: s.sequence("alignment_mask", self.array, "A list of arrays, should be 2 (1 for each SLR)"),
 
   flxcardcontroller: s.record('flxcardcontroller', [
-    s.field("detector_readout_map_file", bootgen.Path, default='./detro_map.json', doc="File containing detector readout map for configuration to run"),
-    s.field("emulator_mode",     bootgen.Flag, default=false, doc="If active, timestamps of data frames are overwritten when processed by the readout. This is necessary if the felix card does not set correct timestamps. Former -e"),
+    s.field("detector_readout_map_file", types.path, default='./detro_map.json', doc="File containing detector readout map for configuration to run"),
+    s.field("emulator_mode",     types.flag, default=false, doc="If active, timestamps of data frames are overwritten when processed by the readout. This is necessary if the felix card does not set correct timestamps. Former -e"),
     s.field("ignore_alignment_mask", self.alignment_mask, default=[[],[]], doc="elink numbers to ignore when checking link alignment."),
   ]),
 
@@ -29,4 +32,4 @@ local cs = {
 };
 
 // Output a topologically sorted array.
-sboot + moo.oschema.sort_select(cs, ns)
+stypes + sboot + moo.oschema.sort_select(cs, ns)

--- a/schema/flxlibs/confgen.jsonnet
+++ b/schema/flxlibs/confgen.jsonnet
@@ -4,8 +4,6 @@ local moo = import "moo.jsonnet";
 
 local sboot = import "daqconf/bootgen.jsonnet";
 local bootgen = moo.oschema.hier(sboot).dunedaq.daqconf.bootgen;
-local sdet = import "daqconf/detectorgen.jsonnet";
-local detectorgen = moo.oschema.hier(sdet).dunedaq.daqconf.detectorgen;
 
 
 local ns = "dunedaq.flxlibs.confgen";
@@ -24,7 +22,6 @@ local cs = {
   ]),
 
   flxlibs_gen: s.record('flxlibs_gen', [
-    s.field('detector',          detectorgen.detector,   default=detectorgen.detector,   doc='detector parameters'),
     s.field('boot',              bootgen.boot,           default=bootgen.boot,           doc='Boot parameters'),
     s.field('flxcardcontroller', self.flxcardcontroller, default=self.flxcardcontroller, doc='FELIX conf parameters'),
   ]),
@@ -32,4 +29,4 @@ local cs = {
 };
 
 // Output a topologically sorted array.
-sboot + sdet + moo.oschema.sort_select(cs, ns)
+sboot + moo.oschema.sort_select(cs, ns)

--- a/schema/flxlibs/confgen.jsonnet
+++ b/schema/flxlibs/confgen.jsonnet
@@ -20,6 +20,7 @@ local cs = {
   ]),
 
   flxlibs_gen: s.record('flxlibs_gen', [
+    s.field('detector',          daqconf.detector,       default=daqconf.detector,       doc='detector parameters'),
     s.field('boot',              daqconf.boot,           default=daqconf.boot,           doc='Boot parameters'),
     s.field('flxcardcontroller', self.flxcardcontroller, default=self.flxcardcontroller, doc='FELIX conf parameters'),
   ]),

--- a/scripts/flx_ctrl_gen
+++ b/scripts/flx_ctrl_gen
@@ -72,10 +72,10 @@ def cli(
 
     moo.otypes.load_types('flxlibs/confgen.jsonnet')
     import dunedaq.flxlibs.confgen as confgen
-    moo.otypes.load_types('daqconf/confgen.jsonnet')
-    import dunedaq.daqconf.confgen as daqconf
+    moo.otypes.load_types('daqconf/bootgen.jsonnet')
+    import dunedaq.daqconf.bootgen as bootgen
 
-    boot = daqconf.boot(**config_data.boot)
+    boot = bootgen.boot(**config_data.boot)
     if debug: console.log(f"boot configuration object: {boot.pod()}")
 
     ## etc...

--- a/scripts/flx_ctrl_gen
+++ b/scripts/flx_ctrl_gen
@@ -6,8 +6,11 @@ import math
 import sys
 import glob
 import rich.traceback
+import shutil
 from rich.console import Console
-from os.path import exists, join
+# from os.path import exists, join
+from pathlib import Path
+
 from daqconf.core.system import System
 from daqconf.core.conf_utils import make_app_command_data
 from daqconf.core.metadata import write_metadata_file
@@ -30,19 +33,39 @@ import click
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @generate_cli_from_schema('flxlibs/confgen.jsonnet', 'flxlibs_gen')
-@click.option('--detector-readout-map-file', default=None, help="File containing detector hardware map for configuration to run")
+@click.option('--force-pm', default=None, type=click.Choice(['ssh', 'k8s']), help="Force process manager")
+@click.option('-m', '--detector-readout-map-file', default=None, help="File containing detector detector-readout map for configuration to run")
 @click.option('-e/-ne','--emulator-mode/--no-emulator-mode', default=None, is_flag=True, help='Emulator mode')
 @click.option('-a', '--only-check-args', default=False, is_flag=True, help="Dry run, do not generate output files")
 @click.option('-n', '--dry-run', default=False, is_flag=True, help="Dry run, do not generate output files")
+@click.option('-f', '--force', default=False, is_flag=True, help="Force configuration generation - delete ")
 @click.option('--debug', default=False, is_flag=True, help="Switch to get a lot of printout and dot files")
 @click.argument('json_dir', type=click.Path())
-def cli(config, detector_readout_map_file, emulator_mode, only_check_args, dry_run, json_dir, debug):
+def cli(
+        config,
+        force_pm,
+        detector_readout_map_file,
+        emulator_mode,
+        only_check_args,
+        dry_run,
+        force,
+        debug,
+        json_dir
+    ):
 
     if only_check_args:
         return
     
-    if exists(json_dir) and not dry_run:
-        raise RuntimeError(f"Directory {json_dir} already exists")
+    output_dir = Path(json_dir)
+    if output_dir.exists():
+        if dry_run:
+            pass
+        elif force:
+            console.log(f"Removing existing {output_dir}")
+            # Delete output folder if it exists
+            shutil.rmtree(output_dir)
+        else:
+            raise RuntimeError(f"Directory {output_dir} already exists")
 
     config_data = config[0]
     config_file = config[1]
@@ -59,11 +82,21 @@ def cli(config, detector_readout_map_file, emulator_mode, only_check_args, dry_r
     flxconf = confgen.flxcardcontroller(**config_data.flxcardcontroller)
     if debug: console.log(f"flxconf configuration object: {flxconf.pod()}")
 
+
+    # Update with command-line options
+    if force_pm is not None:
+        boot.process_manager = force_pm
+        console.log(f"boot.boot.process_manager set to {boot.process_manager}")
+
     if detector_readout_map_file is not None:
+        console.log(f"readout.detector_readout_map_file set to {flxconf.detector_readout_map_file}")
         flxconf.detector_readout_map_file = detector_readout_map_file
 
     if emulator_mode is not None:
+        console.log(f"flxconf.emulator_mode set to {flxconf.emulator_mode}")
         flxconf.emulator_mode = emulator_mode
+
+
     console.print(f'flxconf.emulator_mode {flxconf.emulator_mode}')
     console.log('Loading cardcontrollerapp config generator')
     from flxlibs.cardcontrollerapp import cardcontrollerapp_gen
@@ -105,7 +138,7 @@ def cli(config, detector_readout_map_file, emulator_mode, only_check_args, dry_r
             ru_desc = ru_desc
         )
         the_system.apps[nickname] = app
-        if boot.use_k8s:
+        if boot.process_manager == 'k8s':
             the_system.apps[nickname].resources = {
                 f"felix.cern/flx{ru_desc.iface*2}-ctrl": "1", # requesting FLX {dro_info.card*2}
             }
@@ -129,14 +162,15 @@ def cli(config, detector_readout_map_file, emulator_mode, only_check_args, dry_r
     )
 
     if not dry_run:
-        write_json_files(app_command_datas, system_command_datas, json_dir)
+        write_json_files(app_command_datas, system_command_datas, output_dir)
 
-        console.log(f"FLX card controller apps config generated in {json_dir}")
+        console.log(f"FLX card controller apps config generated in {output_dir}")
 
-        write_metadata_file(json_dir, "flxcardcontrollers_gen", config_file)
+        write_metadata_file(output_dir, "flxcardcontrollers_gen", config_file)
 
 if __name__ == '__main__':
     try:
         cli(show_default=True, standalone_mode=True)
     except Exception as e:
         console.print_exception()
+        raise SystemExit(-1)


### PR DESCRIPTION
Implement the code confgen parameters reorganisation described in DUNE-DAQ/daqconf#330 and DUNE-DAQ/daqconf#354