### PR TITLE
Add Callback support to flxlibs

### DIFF
--- a/include/flxlibs/AvailableParserOperations.hpp
+++ b/include/flxlibs/AvailableParserOperations.hpp
@@ -62,7 +62,7 @@ dump_to_buffer(const char* data,
 
 template<class TargetStruct>
 inline std::function<void(const felix::packetformat::chunk& chunk)>
-fixsizedChunkInto(std::shared_ptr<iomanager::SenderConcept<TargetStruct>>& sink,
+fixsizedChunkInto(std::shared_ptr<std::function<void(TargetStruct&&)>>& cb,
                   std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
   return [&](const felix::packetformat::chunk& chunk) {
@@ -83,19 +83,25 @@ fixsizedChunkInto(std::shared_ptr<iomanager::SenderConcept<TargetStruct>>& sink,
           subchunk_data[i], subchunk_sizes[i], static_cast<void*>(&payload.data), bytes_copied_chunk, target_size);
         bytes_copied_chunk += subchunk_sizes[i];
       }
+      // try {
+      //   // finally, push to sink
+      //   sink->send(std::move(payload), timeout);
+      // } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
+      //   // ers::error(ParserOperationQueuePushFailure(ERS_HERE, " "));
+      // }
       try {
-        // finally, push to sink
-        sink->send(std::move(payload), timeout);
-      } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-        // ers::error(ParserOperationQueuePushFailure(ERS_HERE, " "));
+        (*cb)(std::move(payload));
+      } catch (const std::exception &e) {
+          TLOG() << "Caught " << e.what();
       }
+
     }
   };
 }
 
 template<class TargetStruct>
 inline std::function<void(const felix::packetformat::shortchunk& shortchunk)>
-fixsizedShortchunkInto(std::shared_ptr<iomanager::SenderConcept<TargetStruct>>& sink,
+fixsizedShortchunkInto(std::shared_ptr<std::function<void(TargetStruct&&)>>& cb,
                        std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
   return [&](const felix::packetformat::shortchunk& shortchunk) {
@@ -109,10 +115,9 @@ fixsizedShortchunkInto(std::shared_ptr<iomanager::SenderConcept<TargetStruct>>& 
       TargetStruct payload;
       std::memcpy(static_cast<char*>(payload), shortchunk.data, target_size);
       try {
-        // finally, push to sink
-        sink->send(std::move(payload), timeout);
-      } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-        // ers::error(ParserOperationQueuePushFailure(ERS_HERE, " "));
+        (*cb)(std::move(payload));
+      } catch (const std::exception &e) {
+          TLOG() << "Caught " << e.what();
       }
     }
   };
@@ -120,7 +125,7 @@ fixsizedShortchunkInto(std::shared_ptr<iomanager::SenderConcept<TargetStruct>>& 
 
 template<class TargetStruct>
 inline std::function<void(const felix::packetformat::chunk& chunk)>
-fixsizedChunkViaHeap(std::shared_ptr<iomanager::SenderConcept<TargetStruct*>>& sink,
+fixsizedChunkViaHeap(std::shared_ptr<std::function<void(TargetStruct&&)>>& cb,
                      // std::shared_ptr<iomanager::SenderConcept<std::unique_ptr<TargetStruct>>>& sink,
                      std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
@@ -148,10 +153,9 @@ fixsizedChunkViaHeap(std::shared_ptr<iomanager::SenderConcept<TargetStruct*>>& s
         bytes_copied_chunk += subchunk_sizes[i];
       }
       try {
-        // finally, push to sink
-        sink->send(std::move(payload), timeout); // std::move(std::make_unique<TargetStruct>(payload)), timeout);
-      } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-        // ers::error(ParserOperationQueuePushFailure(ERS_HERE, " "));
+        (*cb)(std::move(payload));
+      } catch (const std::exception &e) {
+          TLOG() << "Caught " << e.what();
       }
     }
   };
@@ -159,7 +163,7 @@ fixsizedChunkViaHeap(std::shared_ptr<iomanager::SenderConcept<TargetStruct*>>& s
 
 template<class TargetWithDatafield>
 inline std::function<void(const felix::packetformat::chunk&)>
-varsizedChunkIntoWithDatafield(std::shared_ptr<iomanager::SenderConcept<TargetWithDatafield>>& sink,
+varsizedChunkIntoWithDatafield(std::shared_ptr<std::function<void(TargetWithDatafield&&)>>& cb,
                                std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
   return [&](const felix::packetformat::chunk& chunk) {
@@ -179,16 +183,16 @@ varsizedChunkIntoWithDatafield(std::shared_ptr<iomanager::SenderConcept<TargetWi
     }
     twd.set_data_size(bytes_copied_chunk);
     try {
-      sink->send(std::move(twd), timeout);
-    } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-      // ers::error
+      (*cb)(std::move(twd));
+    } catch (const std::exception &e) {
+        TLOG() << "Caught " << e.what();
     }
   };
 }
 
 template<class TargetWithDatafield>
 inline std::function<void(const felix::packetformat::shortchunk&)>
-varsizedShortchunkIntoWithDatafield(std::shared_ptr<iomanager::SenderConcept<TargetWithDatafield>>& sink,
+varsizedShortchunkIntoWithDatafield(std::shared_ptr<std::function<void(TargetWithDatafield&&)>>& cb,
                                std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
   return [&](const felix::packetformat::shortchunk& shortchunk) {
@@ -197,15 +201,15 @@ varsizedShortchunkIntoWithDatafield(std::shared_ptr<iomanager::SenderConcept<Tar
     std::memcpy(static_cast<void*>(twd.get_data().data()), shortchunk.data, shortchunk.length);
     twd.set_data_size(shortchunk.length);
     try {
-      sink->send(std::move(twd), timeout);
-    } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-      // ers::error
+      (*cb)(std::move(twd));
+    } catch (const std::exception &e) {
+        TLOG() << "Caught " << e.what();
     }
   };
 }
 
 inline std::function<void(const felix::packetformat::chunk& chunk)>
-varsizedChunkIntoWrapper(std::shared_ptr<iomanager::SenderConcept<fdreadoutlibs::types::VariableSizePayloadTypeAdapter>>& sink,
+varsizedChunkIntoWrapper(std::shared_ptr<std::function<void(fdreadoutlibs::types::VariableSizePayloadTypeAdapter&&)>>& cb,
                          std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
   return [&](const felix::packetformat::chunk& chunk) {
@@ -223,15 +227,15 @@ varsizedChunkIntoWrapper(std::shared_ptr<iomanager::SenderConcept<fdreadoutlibs:
     }
     fdreadoutlibs::types::VariableSizePayloadTypeAdapter payload_wrapper(chunk_length, payload);
     try {
-      sink->send(std::move(payload_wrapper), timeout);
-    } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-      // ers
+      (*cb)(std::move(payload_wrapper));
+    } catch (const std::exception &e) {
+        TLOG() << "Caught " << e.what();
     }
   };
 }
 
 inline std::function<void(const felix::packetformat::shortchunk& shortchunk)>
-varsizedShortchunkIntoWrapper(std::shared_ptr<iomanager::SenderConcept<fdreadoutlibs::types::VariableSizePayloadTypeAdapter>>& sink,
+varsizedShortchunkIntoWrapper(std::shared_ptr<std::function<void(fdreadoutlibs::types::VariableSizePayloadTypeAdapter&&)>>& cb,
                               std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
   return [&](const felix::packetformat::shortchunk& shortchunk) {
@@ -240,24 +244,24 @@ varsizedShortchunkIntoWrapper(std::shared_ptr<iomanager::SenderConcept<fdreadout
     std::memcpy(payload, shortchunk.data, shortchunk_length);
     fdreadoutlibs::types::VariableSizePayloadTypeAdapter payload_wrapper(shortchunk_length, payload);
     try {
-      sink->send(std::move(payload_wrapper), timeout);
-    } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-      // ers
+      (*cb)(std::move(payload_wrapper));
+    } catch (const std::exception &e) {
+        TLOG() << "Caught " << e.what();
     }
   };
 }
 
 
 inline std::function<void(const felix::packetformat::chunk& chunk)>
-errorChunkIntoSink(std::shared_ptr<iomanager::SenderConcept<felix::packetformat::chunk>>& sink,
+errorChunkIntoSink(std::shared_ptr<std::function<void(felix::packetformat::chunk&&)>>& cb,
                    std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
   return [&](const felix::packetformat::chunk& chunk) {
     try {
       auto payload = chunk;
-      sink->send(std::move(payload), timeout);
-    } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-      // ers
+      (*cb)(std::move(payload));
+    } catch (const std::exception &e) {
+        TLOG() << "Caught " << e.what();
     }
   };
 }

--- a/include/flxlibs/AvailableParserOperations.hpp
+++ b/include/flxlibs/AvailableParserOperations.hpp
@@ -120,7 +120,6 @@ fixsizedShortchunkInto(std::shared_ptr<std::function<void(TargetStruct&&)>>& cb,
 template<class TargetStruct>
 inline std::function<void(const felix::packetformat::chunk& chunk)>
 fixsizedChunkViaHeap(std::shared_ptr<std::function<void(TargetStruct&&)>>& cb,
-                     // std::shared_ptr<iomanager::SenderConcept<std::unique_ptr<TargetStruct>>>& sink,
                      std::chrono::milliseconds timeout = std::chrono::milliseconds(100))
 {
   return [&](const felix::packetformat::chunk& chunk) {

--- a/include/flxlibs/AvailableParserOperations.hpp
+++ b/include/flxlibs/AvailableParserOperations.hpp
@@ -83,12 +83,6 @@ fixsizedChunkInto(std::shared_ptr<std::function<void(TargetStruct&&)>>& cb,
           subchunk_data[i], subchunk_sizes[i], static_cast<void*>(&payload.data), bytes_copied_chunk, target_size);
         bytes_copied_chunk += subchunk_sizes[i];
       }
-      // try {
-      //   // finally, push to sink
-      //   sink->send(std::move(payload), timeout);
-      // } catch (const dunedaq::iomanager::TimeoutExpired& excpt) {
-      //   // ers::error(ParserOperationQueuePushFailure(ERS_HERE, " "));
-      // }
       try {
         (*cb)(std::move(payload));
       } catch (const std::exception &e) {

--- a/plugins/FelixReaderModule.cpp
+++ b/plugins/FelixReaderModule.cpp
@@ -110,22 +110,6 @@ FelixReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcfg
         m_block_size = flx_if->get_dma_block_size() * m_1kb_block_size;
         m_chunk_trailer_size = flx_if->get_chunk_trailer_size();
   }
-  
-
-  // for (auto qi : modconf->get_outputs()) {
-  //   auto q_with_id = qi->cast<confmodel::QueueWithSourceId>();
-  //   if (q_with_id == nullptr) continue;
-  //   TLOG_DEBUG(TLVL_WORK_STEPS) << ": CardReader output queue is " << q_with_id->UID();
-  //   TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating ElinkModel for target queue: " << q_with_id->UID() << " DLH number: " << q_with_id->get_source_id();
-  //   auto elink = src_id_to_elink_map[q_with_id->get_source_id()];
-  //   auto link_ptr = m_elinks[elink] = createElinkModel(q_with_id->UID());
-  //   if ( ! link_ptr ) {
-  //     ers::fatal(InitializationError(ERS_HERE, "CreateElink failed to provide an appropriate model for queue!"));
-  //   }
-  //   register_node( q_with_id->UID(), link_ptr);
-  //   link_ptr->init(m_block_queue_capacity);
-  //   //m_elinks[q_with_id->get_source_id()]->init(args, m_block_queue_capacity);
-  // }
 
   for (auto cb :modconf->get_raw_data_callbacks()) {
     auto cb_with_id = cb->cast<appmodel::DataMoveCallbackConf>();

--- a/plugins/FelixReaderModule.cpp
+++ b/plugins/FelixReaderModule.cpp
@@ -11,6 +11,7 @@
 #include "confmodel/DetectorStream.hpp"
 #include "confmodel/GeoId.hpp"
 
+#include "appmodel/DataMoveCallbackConf.hpp"
 #include "appmodel/DataReaderModule.hpp"
 #include "appmodel/FelixDetectorToDaqConnection.hpp"
 #include "appmodel/FelixInterface.hpp"

--- a/plugins/FelixReaderModule.cpp
+++ b/plugins/FelixReaderModule.cpp
@@ -111,19 +111,33 @@ FelixReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcfg
   }
   
 
-  for (auto qi : modconf->get_outputs()) {
-    auto q_with_id = qi->cast<confmodel::QueueWithSourceId>();
-    if (q_with_id == nullptr) continue;
-    TLOG_DEBUG(TLVL_WORK_STEPS) << ": CardReader output queue is " << q_with_id->UID();
-    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating ElinkModel for target queue: " << q_with_id->UID() << " DLH number: " << q_with_id->get_source_id();
-    auto elink = src_id_to_elink_map[q_with_id->get_source_id()];
-    auto link_ptr = m_elinks[elink] = createElinkModel(q_with_id->UID());
+  // for (auto qi : modconf->get_outputs()) {
+  //   auto q_with_id = qi->cast<confmodel::QueueWithSourceId>();
+  //   if (q_with_id == nullptr) continue;
+  //   TLOG_DEBUG(TLVL_WORK_STEPS) << ": CardReader output queue is " << q_with_id->UID();
+  //   TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating ElinkModel for target queue: " << q_with_id->UID() << " DLH number: " << q_with_id->get_source_id();
+  //   auto elink = src_id_to_elink_map[q_with_id->get_source_id()];
+  //   auto link_ptr = m_elinks[elink] = createElinkModel(q_with_id->UID());
+  //   if ( ! link_ptr ) {
+  //     ers::fatal(InitializationError(ERS_HERE, "CreateElink failed to provide an appropriate model for queue!"));
+  //   }
+  //   register_node( q_with_id->UID(), link_ptr);
+  //   link_ptr->init(m_block_queue_capacity);
+  //   //m_elinks[q_with_id->get_source_id()]->init(args, m_block_queue_capacity);
+  // }
+
+  for (atuo cb :modconf->get_raw_data_callbacks()) {
+    auto cb_with_id = cb->cast<appmodel::DataMoveCallbackConf>();
+    if (cb_with_id == nullptr) continue;
+    TLOG_DEBUG(TLVL_WORK_STEPS) << ": CardReader output callback is " << cb_with_id->UID();
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating ElinkModel for target callback: " << cb_with_id->UID() << " DLH number: " << cb_with_id->get_source_id();
+    auto elink = src_id_to_elink_map[cb_with_id->get_source_id()];
+    auto link_ptr = m_elinks[elink] = createElinkModel(cb_with_id->UID());
     if ( ! link_ptr ) {
       ers::fatal(InitializationError(ERS_HERE, "CreateElink failed to provide an appropriate model for queue!"));
     }
-    register_node( q_with_id->UID(), link_ptr);
+    register_node( cb_with_id->UID(), link_ptr);
     link_ptr->init(m_block_queue_capacity);
-    //m_elinks[q_with_id->get_source_id()]->init(args, m_block_queue_capacity);
   }
 
   // Router function of block to appropriate ElinkHandlers

--- a/plugins/FelixReaderModule.cpp
+++ b/plugins/FelixReaderModule.cpp
@@ -127,13 +127,13 @@ FelixReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcfg
   //   //m_elinks[q_with_id->get_source_id()]->init(args, m_block_queue_capacity);
   // }
 
-  for (atuo cb :modconf->get_raw_data_callbacks()) {
+  for (auto cb :modconf->get_raw_data_callbacks()) {
     auto cb_with_id = cb->cast<appmodel::DataMoveCallbackConf>();
     if (cb_with_id == nullptr) continue;
     TLOG_DEBUG(TLVL_WORK_STEPS) << ": CardReader output callback is " << cb_with_id->UID();
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating ElinkModel for target callback: " << cb_with_id->UID() << " DLH number: " << cb_with_id->get_source_id();
     auto elink = src_id_to_elink_map[cb_with_id->get_source_id()];
-    auto link_ptr = m_elinks[elink] = createElinkModel(cb_with_id->UID());
+    auto link_ptr = m_elinks[elink] = createElinkModel(cb_with_id);
     if ( ! link_ptr ) {
       ers::fatal(InitializationError(ERS_HERE, "CreateElink failed to provide an appropriate model for queue!"));
     }
@@ -217,6 +217,7 @@ FelixReaderModule::do_start(const CommandData_t& /*args*/)
 {
     m_card_wrapper->start();
     for (auto& [tag, elink] : m_elinks) {
+      elink->acquire_callback();
       elink->start();
     }
 }

--- a/src/CreateElink.hpp
+++ b/src/CreateElink.hpp
@@ -74,10 +74,8 @@ createElinkModel(const appmodel::DataMoveCallbackConf* conf)
   if (datatype.find("PDSStreamFrame") != std::string::npos) {
     // PDS specific char arrays
     auto elink_model = std::make_unique<ElinkModel<fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>>();
-    // elink_model->set_sink(conn_uid);
     elink_model->set_sink_config(conf);
     auto& parser = elink_model->get_parser();
-    // auto& sink = elink_model->get_sink();
     auto& cb = elink_model->m_sink_callback;
     parser.process_chunk_func = parsers::fixsizedChunkInto<fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>(cb);
     return elink_model;

--- a/src/CreateElink.hpp
+++ b/src/CreateElink.hpp
@@ -18,6 +18,8 @@
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/VariableSizePayloadTypeAdapter.hpp"
 
+#include "appmodel/DataMoveCallbackConf.hpp"
+
 #include <memory>
 #include <string>
 
@@ -31,16 +33,9 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAda
 namespace flxlibs {
 
 std::unique_ptr<ElinkConcept>
-createElinkModel(const std::string& conn_uid)
+createElinkModel(const appmodel::DataMoveCallbackConf* conf)
 {
-  auto datatypes = dunedaq::iomanager::IOManager::get()->get_datatypes(conn_uid);
-  if (datatypes.size() != 1) {
-    ers::error(dunedaq::datahandlinglibs::GenericConfigurationError(ERS_HERE,
-      "Multiple output data types specified! Expected only a single type!"));
-  }
-  std::string raw_dt{ *datatypes.begin() };
-  TLOG() << "Choosing specializations for ElinkModel for output connection "
-         << " [uid:" << conn_uid << " , data_type:" << raw_dt << ']';
+  auto datatype = conf->get_data_type();
 /*
 
   if (raw_dt.find("WIBFrame") != std::string::npos) {
@@ -76,33 +71,35 @@ createElinkModel(const std::string& conn_uid)
     return elink_model;
 
   } else*/ 
-  if (raw_dt.find("PDSStreamFrame") != std::string::npos) {
+  if (datatype.find("PDSStreamFrame") != std::string::npos) {
     // PDS specific char arrays
     auto elink_model = std::make_unique<ElinkModel<fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>>();
-    elink_model->set_sink(conn_uid);
+    // elink_model->set_sink(conn_uid);
+    elink_model->set_sink_config(conf);
     auto& parser = elink_model->get_parser();
-    auto& sink = elink_model->get_sink();
-    parser.process_chunk_func = parsers::fixsizedChunkInto<fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>(sink);
+    // auto& sink = elink_model->get_sink();
+    auto& cb = elink_model->m_sink_callback;
+    parser.process_chunk_func = parsers::fixsizedChunkInto<fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>(cb);
     return elink_model;
 
-  } else if (raw_dt.find("PDSFrame") != std::string::npos) {
+  } else if (datatype.find("PDSFrame") != std::string::npos) {
     // PDS specific char arrays
     auto elink_model = std::make_unique<ElinkModel<fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>>();
-    elink_model->set_sink(conn_uid);
+    elink_model->set_sink_config(conf);
     auto& parser = elink_model->get_parser();
-    auto& sink = elink_model->get_sink();
-    parser.process_chunk_func = parsers::fixsizedChunkInto<fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>(sink);
+    auto& cb = elink_model->m_sink_callback;
+    parser.process_chunk_func = parsers::fixsizedChunkInto<fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>(cb);
     return elink_model;
 
 
-  } else if (raw_dt.find("varsize") != std::string::npos) {
+  } else if (datatype.find("varsize") != std::string::npos) {
     // Variable sized user payloads
     auto elink_model = std::make_unique<ElinkModel<fdreadoutlibs::types::VariableSizePayloadTypeAdapter>>();
-    elink_model->set_sink(conn_uid);
+    elink_model->set_sink_config(conf);
     auto& parser = elink_model->get_parser();
-    auto& sink = elink_model->get_sink();
-    parser.process_chunk_func = parsers::varsizedChunkIntoWrapper(sink);
-    parser.process_shortchunk_func = parsers::varsizedShortchunkIntoWrapper(sink);
+    auto& cb = elink_model->m_sink_callback;
+    parser.process_chunk_func = parsers::varsizedChunkIntoWrapper(cb);
+    parser.process_shortchunk_func = parsers::varsizedShortchunkIntoWrapper(cb);
     return elink_model;
   }
 

--- a/src/ElinkConcept.hpp
+++ b/src/ElinkConcept.hpp
@@ -15,6 +15,7 @@
 #include "appfwk/DAQModule.hpp"
 #include "packetformat/detail/block_parser.hpp"
 
+#include "appmodel/DataMoveCallbackConf.hpp"
 
 #include <memory>
 #include <sstream>
@@ -46,6 +47,8 @@ public:
 
   virtual void init(const size_t block_queue_capacity) = 0;
   virtual void set_sink(const std::string& sink_name) = 0;
+  virtual void acquire_callback() = 0;
+  
   virtual void conf(size_t block_size, bool is_32b_trailers) = 0;
   virtual void start() = 0;
   virtual void stop() = 0;
@@ -54,6 +57,11 @@ public:
 
   DefaultParserImpl& get_parser() { return std::ref(m_parser_impl); }
 
+  void set_sink_config(const appmodel::DataMoveCallbackConf* sink_conf) 
+  { 
+    m_sink_conf = sink_conf; 
+  }
+  
   void set_ids(int card, int slr, int id, int tag)
   {
     m_card_id = card;
@@ -75,7 +83,9 @@ public:
 
   }
 
-protected:
+  const appmodel::DataMoveCallbackConf* m_sink_conf;
+
+  protected:
   // Block Parser
   DefaultParserImpl m_parser_impl;
   std::unique_ptr<felix::packetformat::BlockParser<DefaultParserImpl>> m_parser;

--- a/src/ElinkConcept.hpp
+++ b/src/ElinkConcept.hpp
@@ -46,7 +46,6 @@ public:
   ElinkConcept& operator=(ElinkConcept&&) = delete;      ///< ElinkConcept is not move-assignable
 
   virtual void init(const size_t block_queue_capacity) = 0;
-  virtual void set_sink(const std::string& sink_name) = 0;
   virtual void acquire_callback() = 0;
   
   virtual void conf(size_t block_size, bool is_32b_trailers) = 0;

--- a/src/ElinkModel.hpp
+++ b/src/ElinkModel.hpp
@@ -36,7 +36,6 @@ template<class TargetPayloadType>
 class ElinkModel : public ElinkConcept
 {
 public:
-  using sink_t = iomanager::SenderConcept<TargetPayloadType>;
   using err_sink_t = iomanager::SenderConcept<felix::packetformat::chunk>;
   using inherited = ElinkConcept;
   using data_t = nlohmann::json;
@@ -51,18 +50,6 @@ public:
     , m_parser_thread(0)
   {}
   ~ElinkModel() {}
-
-  void set_sink(const std::string& sink_name) override
-  {
-    if (m_sink_is_set) {
-      TLOG_DEBUG(5) << "ElinkModel sink is already set in initialized!";
-    } else {
-      m_sink_queue = get_iom_sender<TargetPayloadType>(sink_name);
-      m_sink_is_set = true;
-    }
-  }
-
-  std::shared_ptr<sink_t>& get_sink() { return m_sink_queue; }
 
   std::shared_ptr<err_sink_t>& get_error_sink() { return m_error_sink_queue; }
 
@@ -201,7 +188,6 @@ private:
 
   // Sink
   bool m_sink_is_set{ false };
-  std::shared_ptr<sink_t> m_sink_queue;
   std::shared_ptr<err_sink_t> m_error_sink_queue;
 
   // blocks to process

--- a/src/ElinkModel.hpp
+++ b/src/ElinkModel.hpp
@@ -20,6 +20,8 @@
 #include "logging/Logging.hpp"
 #include "utilities/ReusableThread.hpp"
 
+#include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
+
 #include <folly/ProducerConsumerQueue.h>
 #include <nlohmann/json.hpp>
 
@@ -123,6 +125,22 @@ public:
     }
   }
 
+  void acquire_callback() override
+  {
+    if (m_callback_is_acquired) {
+      TLOG_DEBUG(5) << "SourceModel callback is already acquired!";
+    } else {
+      // Getting DataMoveCBRegistry
+      auto dmcbr = datahandlinglibs::DataMoveCallbackRegistry::get();
+      m_sink_callback = dmcbr->get_callback<TargetPayloadType>(inherited::m_sink_conf);
+      m_callback_is_acquired = true;
+    }
+  }
+
+  // Callbacks
+  bool m_callback_is_acquired{ false };
+  using sink_cb_t = std::shared_ptr<std::function<void(TargetPayloadType&&)>>;
+  sink_cb_t m_sink_callback;
 
 protected:
   void generate_opmon_data() override {
@@ -171,6 +189,7 @@ protected:
 	       { "tag", std::to_string(m_link_tag) } } );
 	     
   }
+
 
 private:
   // Types


### PR DESCRIPTION
# Description

This PR is in addition to the DataMoveCallbackRegistry configuration update, and its enforcement with the readout application over the use of queues. The changes replaces the use of IOM queues with callbacks instead.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

To test this, One needs to run with the PDS at EHN1, as the test requires real hardware to test. This was tested and shown to work in run 43067 with PDS readout at NP02.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

